### PR TITLE
SemEHR plugin - add PatientID as a field which can be returned

### DIFF
--- a/Rdmp.Dicom/ExternalApis/SemEHRConfiguration.cs
+++ b/Rdmp.Dicom/ExternalApis/SemEHRConfiguration.cs
@@ -50,7 +50,8 @@ public class SemEHRConfiguration
     {
         { "SOPInstanceUID", "SOPInstanceUID" },
         { "SeriesInstanceUID", "SeriesInstanceUID" },
-        { "StudyInstanceUID", "StudyInstanceUID" }
+        { "StudyInstanceUID", "StudyInstanceUID" },
+        { "PatientID", "PatientID" }
     };
 
     //API Settings


### PR DESCRIPTION
SemEHR plugin - add PatientID as a field which can be returned
Implements #357 