### PR TITLE
Add fix for build

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -59,6 +59,14 @@ jobs:
               </metadata>
           </package>
           EOP
+          rm -f p/windows/windows.dll
+          rm -f p/windows/ja-JP/Terminal.Gui.resources.dll
+          rm -f p/windows/fr-FR/Terminal.Gui.resources.dll
+          rm -f p/windows/pt-PT/Terminal.Gui.resources.dll
+          rm -f p/main/main.dll
+          rm -f p/main/ja-JP/Terminal.Gui.resources.dll
+          rm -f p/main/fr-FR/Terminal.Gui.resources.dll
+          rm -f p/main/pt-PT/Terminal.Gui.resources.dll
           7z a -tzip Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg plugin.nuspec p
           dotnet pack Rdmp.Dicom/Rdmp.Dicom.csproj -c Release -p:Version=${{ steps.version.outputs.version }} --include-source --include-symbols -o .
           cat > testcmd.yaml <<-EOC

--- a/README.md
+++ b/README.md
@@ -21,19 +21,18 @@ Once installed the following functionality is available:
 - [NLP Cohort Building Plugin](./Documentation/NlpPlugin.md)
 
 # Building
+Before Building, ensure the version number is correct within the rdmpdicom.nuspec and sharedAssembly.info file
+You will also need 7zip or an equivalent installed.
 
 Building requires MSBuild 15 or later (or Visual Studio 2017 or later).  You will also need to install the [DotNetCore 2.2 SDK](https://dotnet.microsoft.com/download).
 
 You can build Rdmp.Dicom as a plugin for RDMP by running the following (use the Version number in [SharedAssemblyInfo.cs](SharedAssemblyInfo.cs) in place of 0.0.1)
 
 ```bash
-cd Plugin/windows
-dotnet publish --runtime win-x64 -c Release --self-contained false
-cd ../main
-dotnet publish --runtime win-x64 -c Release --self-contained false
-dotnet publish --runtime linux-x64 -c Release --self-contained false
-cd ../..
-nuget pack ./Rdmp.Dicom.nuspec -Properties Configuration=Release -IncludeReferencedProjects -Symbols -Version 0.0.1
+dotnet publish -p:DebugType=embedded -p:GenerateDocumentation=false Plugin/windows/windows.csproj -c Release -o p/windows
+dotnet publish -p:DebugType=embedded -p:GenerateDocumentation=false Plugin/main/main.csproj -c Release -o p/main
+7z a -tzip Rdmp.Dicom.0.0.1.nupkg hicplugin.nuspec p
+dotnet run --project RDMP/Tools/rdmp/rdmp.csproj -c Release -- pack -p --file Rdmp.Dicom.0.0.1.nupkg --dir yaml
 ```
 
 This will produce a nupkg file (e.g. Rdmp.Dicom.0.0.1.nupkg) which can be consumed by both the RDMP client and dot net core RDMP CLI.

--- a/rdmpdicom.nuspec
+++ b/rdmpdicom.nuspec
@@ -6,7 +6,7 @@
         <authors>Health Informatics Service, University of Dundee</authors>
         <description>Imaging plugin for Research Data Management Platform </description>
         <dependencies>
-            <dependency id="HIC.RDMP.Plugin" version="8.1.0-rc4" />
+            <dependency id="HIC.RDMP.Plugin" version="8.1.0" />
         </dependencies>
     </metadata>
 </package>

--- a/rdmpdicom.nuspec
+++ b/rdmpdicom.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+    <metadata>
+        <id>Rdmp.Dicom</id>
+        <version>6.0.2</version>
+        <authors>Health Informatics Service, University of Dundee</authors>
+        <description>Imaging plugin for Research Data Management Platform </description>
+        <dependencies>
+            <dependency id="HIC.RDMP.Plugin" version="8.1.0-rc4" />
+        </dependencies>
+    </metadata>
+</package>


### PR DESCRIPTION
There was some dll duplication issues with the 8.1.0 release, this removes the problematic files prior to bundling the plugin